### PR TITLE
pip.req raises an exception with pip >= 10.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,10 @@ import os
 import re
 import sys
 
-from pip.req import parse_requirements
+try: # for pip >= 10
+    from pip._internal.req import parse_requirements
+except ImportError: # for pip <= 9.0.3
+    from pip.req import parse_requirements
 from setuptools import setup, find_packages
 
 


### PR DESCRIPTION
Added case for the new pip 10 because i wasn't able to install quantopian-tools otherwise